### PR TITLE
Update CI workflow and Conda environment for compatibility

### DIFF
--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -8,4 +8,7 @@ dependencies:
   - pytest-cov
   - fortran-compiler
   - sphinx
+  - sphinx_rtd_theme
+  - meson-python
+  - ninja
 

--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -2,7 +2,7 @@ name: test
 channels:
   - conda-forge
 dependencies:
-  - numpy=1.21.5
+  - numpy>=1.26
   - obspy
   - pandas
   - pytest-cov

--- a/.github/workflows/deploy-meson.yml
+++ b/.github/workflows/deploy-meson.yml
@@ -63,7 +63,6 @@ jobs:
         if: matrix.python == '3.10' 
         run: |
           cd docs
-          pip install sphinx_rtd_theme
           make html
           touch _build/html/.nojekyll
           cd ..

--- a/.github/workflows/deploy-meson.yml
+++ b/.github/workflows/deploy-meson.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    name: Python ${{ matrix.python-version }}
+    name: Python ${{ matrix.python }}
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     strategy:
@@ -32,11 +32,13 @@ jobs:
     
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
+          channels: conda-forge
+          channel-priority: strict
           environment-file: .github/test_conda_env.yml
           auto-activate-base: false
           python-version: ${{ matrix.python }}
@@ -45,7 +47,6 @@ jobs:
         run: |
           conda info
           conda list
-          conda config --add channels conda-forge
 
       - name: Install
         run: |

--- a/.github/workflows/deploy-meson.yml
+++ b/.github/workflows/deploy-meson.yml
@@ -60,7 +60,7 @@ jobs:
       #     bash <(curl -s https://codecov.io/bash)
 
       - name: Make docs
-        if: matrix.python == '3.9' 
+        if: matrix.python == '3.10' 
         run: |
           cd docs
           pip install sphinx_rtd_theme
@@ -69,7 +69,7 @@ jobs:
           cd ..
 
       - name: Deploy 🚀
-        if: matrix.python == '3.9' 
+        if: matrix.python == '3.10' 
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,14 +59,14 @@ jobs:
       #     pytest -v --cov=pyraysum ../pyraysum/tests/
       #     bash <(curl -s https://codecov.io/bash)
 
-      # - name: Make docs
-      #   if: matrix.python == '3.10' 
-      #   run: |
-      #     cd docs
-      #     pip install sphinx_rtd_theme
-      #     make html
-      #     touch _build/html/.nojekyll
-      #     cd ..
+      - name: Make docs
+        if: matrix.python == '3.10' 
+        run: |
+          cd docs
+          pip install sphinx_rtd_theme
+          make html
+          touch _build/html/.nojekyll
+          cd ..
 
       - name: Deploy 🚀
         if: matrix.python == '3.10' 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,6 @@ jobs:
         if: matrix.python == '3.10' 
         run: |
           cd docs
-          pip install sphinx_rtd_theme
           make html
           touch _build/html/.nojekyll
           cd ..

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    name: Python ${{ matrix.python-version }}
+    name: Python ${{ matrix.python }}
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     strategy:
@@ -32,11 +32,13 @@ jobs:
     
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
+          channels: conda-forge
+          channel-priority: strict
           environment-file: .github/test_conda_env.yml
           auto-activate-base: false
           python-version: ${{ matrix.python }}
@@ -45,7 +47,6 @@ jobs:
         run: |
           conda info
           conda list
-          conda config --add channels conda-forge
 
       - name: Install
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ['3.8', '3.9', '3.10']
+        python: ['3.10', '3.11', '3.12']
 
     defaults:
       run:
@@ -58,17 +58,17 @@ jobs:
       #     pytest -v --cov=pyraysum ../pyraysum/tests/
       #     bash <(curl -s https://codecov.io/bash)
 
-      - name: Make docs
-        if: matrix.python == '3.9' 
-        run: |
-          cd docs
-          pip install sphinx_rtd_theme
-          make html
-          touch _build/html/.nojekyll
-          cd ..
+      # - name: Make docs
+      #   if: matrix.python == '3.10' 
+      #   run: |
+      #     cd docs
+      #     pip install sphinx_rtd_theme
+      #     make html
+      #     touch _build/html/.nojekyll
+      #     cd ..
 
       - name: Deploy 🚀
-        if: matrix.python == '3.9' 
+        if: matrix.python == '3.10' 
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/meson.build
+++ b/meson.build
@@ -54,4 +54,4 @@ py.extension_module('fraysum',
 )
 
 # Install python sources
-install_subdir('pyraysum', install_dir : py.get_install_dir())
+install_subdir('src/pyraysum', install_dir : py.get_install_dir())

--- a/src/pyraysum/__init__.py
+++ b/src/pyraysum/__init__.py
@@ -20,6 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-__version__ = '1.1.0'
+__version__ = '1.3.0'
 
 from .prs import Model, Geometry, Control, Result, run


### PR DESCRIPTION
Hi @wasjabloch, Thanks for considering my update. I did some modifications on CI scripts as follows to solve issues of compatibility with new Python versions.

 This pull request updates the CI workflows and dependencies to support newer Python and NumPy versions, modernizes GitHub Actions usage, and updates the package version. The most important changes are grouped below:

**CI/CD Workflow Updates:**

* Updated supported Python versions in `.github/workflows/deploy.yml` from 3.8/3.9/3.10 to 3.10/3.11/3.12, and changed workflow conditions to deploy and build docs only for Python 3.10 instead of 3.9. Also updated the job naming to use `matrix.python` instead of `matrix.python-version`. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L20-R41) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L61-R72)
* Upgraded `actions/checkout` from version 2 to version 4 in both `.github/workflows/deploy.yml` and `.github/workflows/deploy-meson.yml` for improved security and performance. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L20-R41) [[2]](diffhunk://#diff-87af88bb1c6d2bc720f834344a46598d15e092d9bc8282a5d2c91612cd515fc7L35-R41)
* Added `channels: conda-forge` and `channel-priority: strict` to the Conda setup steps, and removed manual channel addition commands for a cleaner and more reproducible environment setup. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L20-R41) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L48) [[3]](diffhunk://#diff-87af88bb1c6d2bc720f834344a46598d15e092d9bc8282a5d2c91612cd515fc7L35-R41) [[4]](diffhunk://#diff-87af88bb1c6d2bc720f834344a46598d15e092d9bc8282a5d2c91612cd515fc7L48)

**Dependency Updates:**

* Increased the minimum required NumPy version in `.github/test_conda_env.yml` from `1.21.5` to `>=1.26` to ensure compatibility with newer Python versions.
> This is the reason why the actions https://github.com/paudetseis/PyRaysum/actions/runs/22570002269 failed.
